### PR TITLE
Running image as normal user instead of root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,4 @@ test:
 	docker run --rm magicvision/nodejs-dev git --version
 	docker run --rm magicvision/nodejs-dev python --version
 	docker run --rm magicvision/nodejs-dev bower --version
+	docker run --rm magicvision/nodejs-dev sudo whoami

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - git 1.9.1
 - python 2.7.6
 - bower 1.6.5
+- Run commands as a normal user named *ubuntu* with sudo permission
 
 [docker:dind]: https://hub.docker.com/_/docker/#
 [Saas]: https://github.com/sass/sass

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # activate nvm
-export NVM_DIR="/root/.nvm"
+export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
 # if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically


### PR DESCRIPTION
This PR fixes

```
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option

```
